### PR TITLE
github: add a CI build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build toolchain
+
+on:
+  push:
+    branches:
+      - tailscale
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1
+      id: go
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build toolchain
+      run: cd src && ./all.bash
+
+    - name: Archive toolchain
+      run: cd .. && tar --exclude-vcs -zcf go.tar.gz go
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        # Release name can't be the same as tag name, sigh
+        tag_name: build-${{ github.sha }}
+        release_name: ${{ github.sha }}
+        draft: false
+        prerelease: true
+
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ../go.tar.gz
+        asset_name: go.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Delete older builds
+      run: ./.github/workflows/prune_old_builds.sh "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/prune_old_builds.sh
+++ b/.github/workflows/prune_old_builds.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEEP=3
+GITHUB_TOKEN=$1
+
+delete_release() {
+    release_id=$1
+    tag_name=$2
+    set -x
+    curl -X DELETE --header "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/tailscale/go/releases/$release_id"
+    curl -X DELETE --header "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/tailscale/go/git/refs/tags/$tag_name"
+    set +x
+}
+
+curl https://api.github.com/repos/tailscale/go/releases 2>/dev/null |\
+    jq -r '.[] | "\(.published_at) \(.id) \(.tag_name)"' |\
+    egrep '[^ ]+ [^ ]+ build-[0-9a-f]{40}' |\
+    sort |\
+    head --lines=-${KEEP}|\
+    while read date release_id tag_name; do
+        delete_release "$release_id" "$tag_name"
+    done


### PR DESCRIPTION
Adds a CI to this repository, which builds the Go toolchain, tars it up, and sticks it on Github as a release artefact. Given a commit ID in this repo, clients can retrieve the cached toolchain at `https://github.com/tailscale/go/releases/download/build-<commit-sha>/go.tar.gz`.

To avoid blowing up our quota of build assets, we only keep toolchains for the last 3 commits. Building a new toolchain prunes older ones.