### PR TITLE
runtime: set GOMAXPROCS to 1 on iOS

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -711,6 +711,9 @@ func schedinit() {
 	lock(&sched.lock)
 	sched.lastpoll = uint64(nanotime())
 	procs := ncpu
+	if sys.GoosIos != 0 {
+		procs = 1
+	}
 	if n, ok := atoi32(gogetenv("GOMAXPROCS")); ok && n > 0 {
 		procs = n
 	}


### PR DESCRIPTION
This is part of an attempt to reduce memory usage on iOS.
We were setting GOMAXPROCS to 1 by calling runtime.GOMAXPROCS,
but by the time we get that opportunity, the runtime
has already allocated more Ms than we would like.
