### PR TITLE
all: add immutability instrumentation [WIP]

### DIFF
--- a/src/cmd/compile/internal/base/flag.go
+++ b/src/cmd/compile/internal/base/flag.go
@@ -113,6 +113,7 @@ type CmdFlags struct {
 	NoLocalImports     bool         "help:\"reject local (relative) imports\""
 	Pack               bool         "help:\"write to file.a instead of file.o\""
 	Race               bool         "help:\"enable race detector\""
+	RaceNoReads        bool         "help:\"disable race detector read instrumentation\""
 	Shared             *bool        "help:\"generate code that can be linked into a shared library\"" // &Ctxt.Flag_shared, set below
 	SmallFrames        bool         "help:\"reduce the size limit for stack allocated objects\""      // small stacks, to diagnose GC latency; see golang.org/issue/27732
 	Spectre            string       "help:\"enable spectre mitigations in `list` (all, index, ret)\""

--- a/src/cmd/compile/internal/ssagen/ssa.go
+++ b/src/cmd/compile/internal/ssagen/ssa.go
@@ -1314,6 +1314,9 @@ func (s *state) instrument2(t *types.Type, addr, addr2 *ssa.Value, kind instrume
 	if !s.curfn.InstrumentBody() {
 		return
 	}
+	if base.Flag.RaceNoReads && kind == instrumentRead {
+		return
+	}
 
 	w := t.Size()
 	if w == 0 {

--- a/src/reflect/freeze.go
+++ b/src/reflect/freeze.go
@@ -1,0 +1,72 @@
+package reflect
+
+import (
+	"internal/race"
+	"sync"
+	"unsafe"
+)
+
+func Freeze(x interface{}) {
+	if !race.Enabled {
+		return
+	}
+	v := ValueOf(x)
+	if v.Kind() != Ptr {
+		panic("cannot freeze non-pointers")
+	}
+	var wg sync.WaitGroupNoRace
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		touch(v)
+	}()
+	wg.Wait()
+}
+
+// touch reads v and writes it back out unchanged.
+// TODO: handle cycles
+func touch(v Value) {
+	if !v.IsValid() || v.typ.size != ptrSize || !v.typ.pointers() {
+		return
+	}
+
+	if race.Enabled {
+		var ptr unsafe.Pointer
+		if v.flag&flagIndir != 0 {
+			ptr = *(*unsafe.Pointer)(v.ptr)
+		} else {
+			ptr = v.ptr
+		}
+		race.WriteRange(ptr, int(v.typ.size))
+	}
+
+	// recurse into things v points to
+	switch v.Kind() {
+	default:
+		panic("touch: unhandled kind: " + v.Kind().String())
+	case Ptr:
+		touch(v.Elem())
+	case Struct:
+		for i, n := 0, v.NumField(); i < n; i++ {
+			// TODO: does this reach unexported fields?
+			touch(v.Field(i))
+		}
+	case Slice, Array:
+		for i, n := 0, v.Len(); i < n; i++ {
+			touch(v.Index(i))
+		}
+	case Interface:
+		touch(v.Elem())
+	case Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			touch(iter.Key())
+			touch(iter.Value())
+		}
+	case String:
+	case Bool:
+	case Int8, Int16, Int32, Int64, Int:
+	case Uint8, Uint16, Uint32, Uint64, Uint, Uintptr:
+	case Float32, Float64, Complex64, Complex128:
+	}
+}

--- a/src/sync/waitgroup_norace.go
+++ b/src/sync/waitgroup_norace.go
@@ -1,0 +1,101 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sync
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// A WaitGroupNoRace is a WaitGroup that does not
+// generate race detector synchronization edges.
+// It is only for use with the immutability detector.
+type WaitGroupNoRace struct {
+	noCopy noCopy
+
+	// 64-bit value: high 32 bits are counter, low 32 bits are waiter count.
+	// 64-bit atomic operations require 64-bit alignment, but 32-bit
+	// compilers do not ensure it. So we allocate 12 bytes and then use
+	// the aligned 8 bytes in them as state, and the other 4 as storage
+	// for the sema.
+	state1 [3]uint32
+}
+
+// state returns pointers to the state and sema fields stored within wg.state1.
+func (wg *WaitGroupNoRace) state() (statep *uint64, semap *uint32) {
+	if uintptr(unsafe.Pointer(&wg.state1))%8 == 0 {
+		return (*uint64)(unsafe.Pointer(&wg.state1)), &wg.state1[2]
+	} else {
+		return (*uint64)(unsafe.Pointer(&wg.state1[1])), &wg.state1[0]
+	}
+}
+
+// Add adds delta, which may be negative, to the WaitGroup counter.
+// If the counter becomes zero, all goroutines blocked on Wait are released.
+// If the counter goes negative, Add panics.
+//
+// Note that calls with a positive delta that occur when the counter is zero
+// must happen before a Wait. Calls with a negative delta, or calls with a
+// positive delta that start when the counter is greater than zero, may happen
+// at any time.
+// Typically this means the calls to Add should execute before the statement
+// creating the goroutine or other event to be waited for.
+// If a WaitGroup is reused to wait for several independent sets of events,
+// new Add calls must happen after all previous Wait calls have returned.
+// See the WaitGroup example.
+func (wg *WaitGroupNoRace) Add(delta int) {
+	statep, semap := wg.state()
+	state := atomic.AddUint64(statep, uint64(delta)<<32)
+	v := int32(state >> 32)
+	w := uint32(state)
+	if v < 0 {
+		panic("sync: negative WaitGroup counter")
+	}
+	if w != 0 && delta > 0 && v == int32(delta) {
+		panic("sync: WaitGroup misuse: Add called concurrently with Wait")
+	}
+	if v > 0 || w == 0 {
+		return
+	}
+	// This goroutine has set counter to 0 when waiters > 0.
+	// Now there can't be concurrent mutations of state:
+	// - Adds must not happen concurrently with Wait,
+	// - Wait does not increment waiters if it sees counter == 0.
+	// Still do a cheap sanity check to detect WaitGroup misuse.
+	if *statep != state {
+		panic("sync: WaitGroup misuse: Add called concurrently with Wait")
+	}
+	// Reset waiters count to 0.
+	*statep = 0
+	for ; w != 0; w-- {
+		runtime_Semrelease(semap, false, 0)
+	}
+}
+
+// Done decrements the WaitGroup counter by one.
+func (wg *WaitGroupNoRace) Done() {
+	wg.Add(-1)
+}
+
+// Wait blocks until the WaitGroup counter is zero.
+func (wg *WaitGroupNoRace) Wait() {
+	statep, semap := wg.state()
+	for {
+		state := atomic.LoadUint64(statep)
+		v := int32(state >> 32)
+		if v == 0 {
+			// Counter is 0, no need to wait.
+			return
+		}
+		// Increment waiters count.
+		if atomic.CompareAndSwapUint64(statep, state, state+1) {
+			runtime_Semacquire(semap)
+			if *statep != 0 {
+				panic("sync: WaitGroup is reused before previous Wait has returned")
+			}
+			return
+		}
+	}
+}


### PR DESCRIPTION
Quick hack using the runtime.

To use, given a value x that you want to be immutable,
call `reflect.Freeze(&x)`.

Then run your program with `-race -gcflags=all=-racenoreads`.

Writes to `x` will cause a race detector panic.
Reads from `x` can proceed as normal.

Sample program:

```go
package main

import (
	"fmt"
	"reflect"
)

func main() {
	var x [2][2]string
	reflect.Freeze(&x)
	fmt.Println(x)
	x[0][0] = "a"
}
```