### PR TITLE
.github: build a darwin-arm64 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,36 @@ jobs:
         name: darwin
         path: ../darwin.tar.gz
 
+  darwin-arm64:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: build
+      run: cd src && ./make.bash
+      env:
+        GOOS: darwin
+        GOARCH: arm64
+    - name: trim unnecessary bits
+      run: |
+        rm -rf pkg/*_* pkg/tool/linux_amd64 bin/go bin/gofmt
+        mv bin/darwin_arm64/* bin/
+        find . -type d -name 'testdata' -print0 | xargs -0 rm -rf
+        find . -name '*_test.go' -delete
+    - name: archive
+      run: cd .. && tar --exclude-vcs -zcf darwin-arm64.tar.gz go
+    - name: save
+      uses: actions/upload-artifact@v1
+      with:
+        name: darwin-arm64
+        path: ../darwin-arm64.tar.gz
+
+
   release:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-    needs: [test, linux, darwin]
+    needs: [test, linux, darwin, darwin-arm64]
     steps:
     - name: download linux
       uses: actions/download-artifact@v1
@@ -78,6 +104,10 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: darwin
+    - name: download darwin-arm64
+      uses: actions/download-artifact@v1
+      with:
+        name: darwin-arm64
     - name: create release
       id: create_release
       uses: actions/create-release@v1
@@ -106,6 +136,15 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: darwin/darwin.tar.gz
         asset_name: darwin.tar.gz
+        asset_content_type: application/gzip
+    - name: upload darwin-arm64 tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: darwin-arm64/darwin-arm64.tar.gz
+        asset_name: darwin-arm64.tar.gz
         asset_content_type: application/gzip
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
cargo-culting here the yaml here.

not changing the name of darwin.tar.gz to avoid all the redo script complications. maybe later.