### PR TITLE
[tailscale1.20] .github/workflows: add a static build for testing.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,29 @@ jobs:
         name: linux
         path: ../linux.tar.gz
 
+  linux-static:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: build
+      run: cd src && ./make.bash
+      env:
+        CGO_ENABLED: "0"
+    - name: trim unnecessary bits
+      run: |
+        rm -rf pkg/*_*
+        find . -type d -name 'testdata' -print0 | xargs -0 rm -rf
+        find . -name '*_test.go' -delete
+    - name: archive
+      run: cd .. && tar --exclude-vcs -zcf linux-static.tar.gz go
+    - name: save
+      uses: actions/upload-artifact@v1
+      with:
+        name: linux-static
+        path: ../linux-static.tar.gz
+
   darwin:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push'
@@ -128,6 +151,10 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: linux
+    - name: download linux-static
+      uses: actions/download-artifact@v1
+      with:
+        name: linux-static
     - name: download darwin
       uses: actions/download-artifact@v1
       with:
@@ -159,6 +186,15 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: linux/linux.tar.gz
         asset_name: linux.tar.gz
+        asset_content_type: application/gzip
+    - name: upload linux-static tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: linux-static/linux-static.tar.gz
+        asset_name: linux-static.tar.gz
         asset_content_type: application/gzip
     - name: upload linux-arm64 tarball
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Only x86 linux for now, to try out using a static toolchain.

Signed-off-by: David Anderson <dave@natulte.net>
