### PR TITLE
[tailscale1.20] cmd/dist: always default to CGO_ENABLED=""

### DIFF
--- a/src/cmd/dist/buildgo.go
+++ b/src/cmd/dist/buildgo.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -114,7 +113,7 @@ func mkzcgo(dir, file string) {
 	fmt.Fprintln(&buf)
 	fmt.Fprintf(&buf, "package build\n")
 	fmt.Fprintln(&buf)
-	fmt.Fprintf(&buf, "const defaultCGO_ENABLED = %q\n", os.Getenv("CGO_ENABLED"))
+	fmt.Fprintf(&buf, "const defaultCGO_ENABLED = %q\n", "")
 	fmt.Fprintln(&buf)
 	fmt.Fprintf(&buf, "var cgoEnabled = map[string]bool{\n")
 	for _, plat := range list {


### PR DESCRIPTION
Lets us build a statically linked toolchain that has the same cgo default as the standard dynamic toolchain.

Signed-off-by: David Anderson <danderson@tailscale.com>