### PR TITLE
[tailscale1.20] time: add /etc/zoneinfo as valid path for tzdata for NixOS

### DIFF
--- a/src/time/zoneinfo_unix.go
+++ b/src/time/zoneinfo_unix.go
@@ -16,11 +16,13 @@ import (
 )
 
 // Many systems use /usr/share/zoneinfo, Solaris 2 has
-// /usr/share/lib/zoneinfo, IRIX 6 has /usr/lib/locale/TZ.
+// /usr/share/lib/zoneinfo, IRIX 6 has /usr/lib/locale/TZ,
+// NixOS has /etc/zoneinfo.
 var platformZoneSources = []string{
 	"/usr/share/zoneinfo/",
 	"/usr/share/lib/zoneinfo/",
 	"/usr/lib/locale/TZ/",
+	"/etc/zoneinfo",
 }
 
 func initLocal() {


### PR DESCRIPTION
NixOS has no /usr/share, but does have tzdata at /etc/zoneinfo.

Change-Id: Ic7d7f42a215e06c2e4f5c54ee11db82240f27167
Signed-off-by: David Anderson <danderson@tailscale.com>
