### PR TITLE
[tailscale] runtime: disable osinit_hack on iOS as a test

### DIFF
--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -137,7 +137,9 @@ func osinit() {
 	ncpu = getncpu()
 	physPageSize = getPageSize()
 
-	osinit_hack()
+	if GOOS != "ios" {
+		osinit_hack()
+	}
 }
 
 func sysctlbynameInt32(name []byte) (int32, int32) {


### PR DESCRIPTION
Updates tailscale/corp#9061
Updates golang/go#58323
