### PR TITLE
[tailscale] net: add TCP socket creation/close hooks to SockTrace API

### DIFF
--- a/api/go1.99999.txt
+++ b/api/go1.99999.txt
@@ -6,3 +6,5 @@ pkg net, type SockTrace struct #58
 pkg net, type SockTrace struct, DidRead func(int) #58
 pkg net, type SockTrace struct, DidWrite func(int) #58
 pkg net, type SockTrace struct, WillOverwrite func(*SockTrace) #58
+pkg net, type SockTrace struct, DidCreateTCPConn func(syscall.RawConn) #58
+pkg net, type SockTrace struct, WillCloseTCPConn func(syscall.RawConn) #58

--- a/src/net/socktrace.go
+++ b/src/net/socktrace.go
@@ -6,12 +6,16 @@ package net
 
 import (
 	"context"
+	"syscall"
 )
 
 // SockTrace is a set of hooks to run at various operations on a network socket.
 // Any particular hook may be nil. Functions may be called concurrently from
 // different goroutines.
 type SockTrace struct {
+	// DidOpenTCPConn is called when a TCP socket was created. The
+	// underlying raw network connection that was created is provided.
+	DidCreateTCPConn func(c syscall.RawConn)
 	// DidRead is called after a successful read from the socket, where n bytes
 	// were read.
 	DidRead func(n int)
@@ -22,6 +26,9 @@ type SockTrace struct {
 	// subsequent call to WithSockTrace. The provided trace is the new trace
 	// that will be used.
 	WillOverwrite func(trace *SockTrace)
+	// WillCloseTCPConn is called when a TCP socket is about to be closed. The
+	// underlying raw network connection that is being closed is provided.
+	WillCloseTCPConn func(c syscall.RawConn)
 }
 
 // WithSockTrace returns a new context based on the provided parent


### PR DESCRIPTION
Extends the hooks added by #45 to also expose when TCP sockets are created or closed (meant to allow TCP stats to be read from them). We don't do this for all socket types since stats are not available for UDP sockets, and they tend to be short-lived, thus invoking the hooks would be useless overhead.

Also fixes read/write hooks to not count out-of-band data, since that's usually not sent over the wire.

Updates tailscale/corp#9230
Updates #58