### PR TITLE
net/http: add Transport.RoundTrip enforcement hook

### DIFF
--- a/api/go1.99999.txt
+++ b/api/go1.99999.txt
@@ -1,5 +1,6 @@
 pkg net, func SetDialEnforcer(func(context.Context, []Addr) error) #55
 pkg net, func SetResolveEnforcer(func(context.Context, string, string, string, Addr) error) #55
+pkg net/http, func SetRoundTripEnforcer(func(*Request) error) #55
 pkg net, func WithSockTrace(context.Context, *SockTrace) context.Context #58
 pkg net, func ContextSockTrace(context.Context) *SockTrace #58
 pkg net, type SockTrace struct #58

--- a/src/net/http/tailscale.go
+++ b/src/net/http/tailscale.go
@@ -1,0 +1,21 @@
+package http
+
+var roundTripEnforcer func(*Request) error
+
+// SetRoundTripEnforcer set a program-global resolver enforcer that can cause
+// RoundTrip calls to fail based on the request and its context.
+//
+// f must be non-nil.
+//
+// SetRoundTripEnforcer can only be called once, and must not be called
+// concurrent with any RoundTrip call; it's expected to be registered during
+// init.
+func SetRoundTripEnforcer(f func(*Request) error) {
+	if f == nil {
+		panic("nil func")
+	}
+	if roundTripEnforcer != nil {
+		panic("already called")
+	}
+	roundTripEnforcer = f
+}

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -511,6 +511,11 @@ func (t *Transport) alternateRoundTripper(req *Request) RoundTripper {
 
 // roundTrip implements a RoundTripper over HTTP.
 func (t *Transport) roundTrip(req *Request) (*Response, error) {
+	if roundTripEnforcer != nil {
+		if err := roundTripEnforcer(req); err != nil {
+			return nil, err
+		}
+	}
 	t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
 	ctx := req.Context()
 	trace := httptrace.ContextClientTrace(ctx)


### PR DESCRIPTION
net/http: add enforcement hook to Transport.RoundTrip, like our net ones

Updates https://github.com/tailscale/go/issues/55
Updates https://github.com/tailscale/corp/issues/12702