### PR TITLE
bump Go

### DIFF
--- a/src/cmd/cgo/internal/testplugin/plugin_test.go
+++ b/src/cmd/cgo/internal/testplugin/plugin_test.go
@@ -397,3 +397,10 @@ func TestSymbolNameMangle(t *testing.T) {
 	globalSkip(t)
 	goCmd(t, "build", "-buildmode=plugin", "-o", "mangle.so", "./mangle/plugin.go")
 }
+
+func TestIssue62430(t *testing.T) {
+	globalSkip(t)
+	goCmd(t, "build", "-buildmode=plugin", "-o", "issue62430.so", "./issue62430/plugin.go")
+	goCmd(t, "build", "-o", "issue62430.exe", "./issue62430/main.go")
+	run(t, "./issue62430.exe")
+}

--- a/src/cmd/cgo/internal/testplugin/testdata/issue62430/main.go
+++ b/src/cmd/cgo/internal/testplugin/testdata/issue62430/main.go
@@ -1,0 +1,35 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Issue 62430: a program that uses plugins may appear
+// to have no references to an initialized global map variable defined
+// in some stdlib package (ex: unicode), however there
+// may be references to that map var from a plugin that
+// gets loaded.
+
+package main
+
+import (
+	"fmt"
+	"plugin"
+	"unicode"
+)
+
+func main() {
+	p, err := plugin.Open("issue62430.so")
+	if err != nil {
+		panic(err)
+	}
+	s, err := p.Lookup("F")
+	if err != nil {
+		panic(err)
+	}
+
+	f := s.(func(string) *unicode.RangeTable)
+	if f("C") == nil {
+		panic("unicode.Categories not properly initialized")
+	} else {
+		fmt.Println("unicode.Categories properly initialized")
+	}
+}

--- a/src/cmd/cgo/internal/testplugin/testdata/issue62430/plugin.go
+++ b/src/cmd/cgo/internal/testplugin/testdata/issue62430/plugin.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"unicode"
+)
+
+func F(s string) *unicode.RangeTable {
+	return unicode.Categories[s]
+}
+
+func main() {}

--- a/src/cmd/compile/internal/ssa/memcombine.go
+++ b/src/cmd/compile/internal/ssa/memcombine.go
@@ -41,6 +41,7 @@ func memcombineLoads(f *Func) {
 		}
 	}
 	for _, b := range f.Blocks {
+		order = order[:0]
 		for _, v := range b.Values {
 			if v.Op != OpOr16 && v.Op != OpOr32 && v.Op != OpOr64 {
 				continue

--- a/src/cmd/link/internal/ld/deadcode.go
+++ b/src/cmd/link/internal/ld/deadcode.go
@@ -141,10 +141,26 @@ func (d *deadcodePass) flood() {
 		methods = methods[:0]
 		for i := 0; i < relocs.Count(); i++ {
 			r := relocs.At(i)
-			// When build with "-linkshared", we can't tell if the interface
-			// method in itab will be used or not. Ignore the weak attribute.
-			if r.Weak() && !(d.ctxt.linkShared && d.ldr.IsItab(symIdx)) {
-				continue
+			if r.Weak() {
+				convertWeakToStrong := false
+				// When build with "-linkshared", we can't tell if the
+				// interface method in itab will be used or not.
+				// Ignore the weak attribute.
+				if d.ctxt.linkShared && d.ldr.IsItab(symIdx) {
+					convertWeakToStrong = true
+				}
+				// If the program uses plugins, we can no longer treat
+				// relocs from pkg init functions to outlined map init
+				// fragments as weak, since doing so can cause package
+				// init clashes between the main program and the
+				// plugin. See #62430 for more details.
+				if d.ctxt.canUsePlugins && r.Type().IsDirectCall() {
+					convertWeakToStrong = true
+				}
+				if !convertWeakToStrong {
+					// skip this reloc
+					continue
+				}
 			}
 			t := r.Type()
 			switch t {

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -1418,6 +1418,10 @@ func (ctxt *Link) hostlink() {
 			// resolving a lazy binding. See issue 38824.
 			// Force eager resolution to work around.
 			argv = append(argv, "-Wl,-flat_namespace", "-Wl,-bind_at_load")
+			if linkerFlagSupported(ctxt.Arch, argv[0], "", "-Wl,-ld_classic") {
+				// Force old linker to work around a bug in Apple's new linker.
+				argv = append(argv, "-Wl,-ld_classic")
+			}
 		}
 		if !combineDwarf {
 			argv = append(argv, "-Wl,-S") // suppress STAB (symbolic debugging) symbols

--- a/src/cmd/link/internal/ld/lib.go
+++ b/src/cmd/link/internal/ld/lib.go
@@ -1902,6 +1902,16 @@ func (ctxt *Link) hostlink() {
 				out = append(out[:i], out[i+len(noPieWarning):]...)
 			}
 		}
+		if ctxt.IsDarwin() {
+			const bindAtLoadWarning = "ld: warning: -bind_at_load is deprecated on macOS\n"
+			if i := bytes.Index(out, []byte(bindAtLoadWarning)); i >= 0 {
+				// -bind_at_load is deprecated with ld-prime, but needed for
+				// correctness with older versions of ld64. Swallow the warning.
+				// TODO: maybe pass -bind_at_load conditionally based on C
+				// linker version.
+				out = append(out[:i], out[i+len(bindAtLoadWarning):]...)
+			}
+		}
 		ctxt.Logf("%s", out)
 	}
 

--- a/src/cmd/link/internal/ld/main.go
+++ b/src/cmd/link/internal/ld/main.go
@@ -197,6 +197,10 @@ func Main(arch *sys.Arch, theArch Arch) {
 
 	checkStrictDups = *FlagStrictDups
 
+	if ctxt.IsDarwin() && ctxt.BuildMode == BuildModeCShared {
+		*FlagW = true // default to -w in c-shared mode on darwin, see #61229
+	}
+
 	if !buildcfg.Experiment.RegabiWrappers {
 		abiInternalVer = 0
 	}

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1543,7 +1543,7 @@ func mstart0() {
 		// but is somewhat arbitrary.
 		size := gp.stack.hi
 		if size == 0 {
-			size = 8192 * sys.StackGuardMultiplier
+			size = 16384 * sys.StackGuardMultiplier
 		}
 		gp.stack.hi = uintptr(noescape(unsafe.Pointer(&size)))
 		gp.stack.lo = gp.stack.hi - size + 1024
@@ -1939,7 +1939,7 @@ func allocm(pp *p, fn func(), id int64) *m {
 	if iscgo || mStackIsSystemAllocated() {
 		mp.g0 = malg(-1)
 	} else {
-		mp.g0 = malg(8192 * sys.StackGuardMultiplier)
+		mp.g0 = malg(16384 * sys.StackGuardMultiplier)
 	}
 	mp.g0.m = mp
 


### PR DESCRIPTION
- [release-branch.go1.21] cmd/link: avoid deadcode of global map vars for programs using plugins
- [release-branch.go1.21] cmd/link: force old Apple linker in plugin mode
- [release-branch.go1.21] cmd/link: disable DWARF by default in c-shared mode on darwin
- [release-branch.go1.21] cmd/link: suppress -bind_at_load deprecation warning for ld-prime
- [release-branch.go1.21] runtime: increase g0 stack size in non-cgo case
- [release-branch.go1.21] runtime: always lock OS thread in debugcall
- [release-branch.go1.21] cmd/compile: reset memcombine correctly between basic blocks
