### PR TITLE
Update go1.22.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ on:
   pull_request:
     branches:
       - '*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, commit or tag to build from
+        required: true
+        default: 'tailscale.go1.21'
 
 jobs:
   test:
@@ -18,6 +24,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref || github.ref }}
     - name: test
       run: cd src && ./all.bash
 
@@ -27,10 +35,12 @@ jobs:
         GOOS: ["linux", "darwin"]
         GOARCH: ["amd64", "arm64"]
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push'
+    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:
     - name: checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref || github.ref }}
     - name: build
       run: cd src && ./make.bash
       env:
@@ -57,7 +67,7 @@ jobs:
 
   create_release:
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push'
+    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [test, build_release]
     outputs:
       url: ${{ steps.create_release.outputs.upload_url }}
@@ -80,7 +90,7 @@ jobs:
         GOOS: ["linux", "darwin"]
         GOARCH: ["amd64", "arm64"]
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push'
+    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [create_release]
     steps:
     - name: download artifact
@@ -99,10 +109,14 @@ jobs:
 
   clean_old:
     runs-on: ubuntu-20.04
+    # Do not clean up old builds on workflow_dispatch to allow temporarily
+    # re-creating old releases for backports.
     if: github.event_name == 'push'
     needs: [upload_release]
     steps:
     - name: checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref || github.ref }}
     - name: Delete older builds
       run: ./.github/workflows/prune_old_builds.sh "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         # Release name can't be the same as tag name, sigh
-        tag_name: build-${{ github.sha }}
-        release_name: ${{ github.sha }}
+        tag_name: build-${{ inputs.ref || github.sha }}
+        release_name: ${{ inputs.ref || github.sha }}
         draft: false
         prerelease: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,108 @@
+name: Build toolchain
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - tailscale
+      - 'tailscale.go1.21'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: test
+      run: cd src && ./all.bash
+
+  build_release:
+    strategy:
+      matrix:
+        GOOS: ["linux", "darwin"]
+        GOARCH: ["amd64", "arm64"]
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: build
+      run: cd src && ./make.bash
+      env:
+        GOOS: "${{ matrix.GOOS }}"
+        GOARCH: "${{ matrix.GOARCH }}"
+        CGO_ENABLED: "0"
+    - name: trim unnecessary bits
+      run: |
+        rm -rf pkg/*_*
+        mv pkg/tool/${{ matrix.GOOS }}_${{ matrix.GOARCH }} pkg
+        rm -rf pkg/tool/*_*
+        mv -f bin/${{ matrix.GOOS }}_${{ matrix.GOARCH }}/* bin/ || true
+        rm -rf bin/${{ matrix.GOOS }}_${{ matrix.GOARCH }}
+        mv pkg/${{ matrix.GOOS }}_${{ matrix.GOARCH }} pkg/tool
+        find . -type d -name 'testdata' -print0 | xargs -0 rm -rf
+        find . -name '*_test.go' -delete
+    - name: archive
+      run: cd .. && tar --exclude-vcs -zcf ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz go
+    - name: save
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+        path: ../${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+
+  create_release:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+    needs: [test, build_release]
+    outputs:
+      url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+    - name: create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        # Release name can't be the same as tag name, sigh
+        tag_name: build-${{ github.sha }}
+        release_name: ${{ github.sha }}
+        draft: false
+        prerelease: true
+
+  upload_release:
+    strategy:
+      matrix:
+        GOOS: ["linux", "darwin"]
+        GOARCH: ["amd64", "arm64"]
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+    needs: [create_release]
+    steps:
+    - name: download artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+    - name: upload artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.url }}
+        asset_path: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}/${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+        asset_name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+        asset_content_type: application/gzip
+
+  clean_old:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+    needs: [upload_release]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: Delete older builds
+      run: ./.github/workflows/prune_old_builds.sh "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/prune_old_builds.sh
+++ b/.github/workflows/prune_old_builds.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEEP=10
+GITHUB_TOKEN=$1
+
+delete_release() {
+    release_id=$1
+    tag_name=$2
+    set -x
+    curl -X DELETE --header "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/tailscale/go/releases/$release_id"
+    curl -X DELETE --header "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/tailscale/go/git/refs/tags/$tag_name"
+    set +x
+}
+
+curl https://api.github.com/repos/tailscale/go/releases 2>/dev/null |\
+    jq -r '.[] | "\(.published_at) \(.id) \(.tag_name)"' |\
+    egrep '[^ ]+ [^ ]+ build-[0-9a-f]{40}' |\
+    sort |\
+    head --lines=-${KEEP}|\
+    while read date release_id tag_name; do
+        delete_release "$release_id" "$tag_name"
+    done

--- a/api/go1.99999.txt
+++ b/api/go1.99999.txt
@@ -1,2 +1,8 @@
 pkg net, func SetDialEnforcer(func(context.Context, []Addr) error) #55
 pkg net, func SetResolveEnforcer(func(context.Context, string, string, string, Addr) error) #55
+pkg net, func WithSockTrace(context.Context, *SockTrace) context.Context #58
+pkg net, func ContextSockTrace(context.Context) *SockTrace #58
+pkg net, type SockTrace struct #58
+pkg net, type SockTrace struct, DidRead func(int) #58
+pkg net, type SockTrace struct, DidWrite func(int) #58
+pkg net, type SockTrace struct, WillOverwrite func(*SockTrace) #58

--- a/api/go1.99999.txt
+++ b/api/go1.99999.txt
@@ -6,3 +6,5 @@ pkg net, type SockTrace struct #58
 pkg net, type SockTrace struct, DidRead func(int) #58
 pkg net, type SockTrace struct, DidWrite func(int) #58
 pkg net, type SockTrace struct, WillOverwrite func(*SockTrace) #58
+pkg net, type SockTrace struct, DidCreateTCPConn func(syscall.RawConn) #58
+pkg net, type SockTrace struct, WillCloseTCPConn func(syscall.RawConn) #58

--- a/api/go1.99999.txt
+++ b/api/go1.99999.txt
@@ -1,0 +1,2 @@
+pkg net, func SetDialEnforcer(func(context.Context, []Addr) error) #55
+pkg net, func SetResolveEnforcer(func(context.Context, string, string, string, Addr) error) #55

--- a/api/go1.99999.txt
+++ b/api/go1.99999.txt
@@ -1,5 +1,6 @@
 pkg net, func SetDialEnforcer(func(context.Context, []Addr) error) #55
 pkg net, func SetResolveEnforcer(func(context.Context, string, string, string, Addr) error) #55
+pkg net/http, func SetRoundTripEnforcer(func(*Request) error) #55
 pkg net, func WithSockTrace(context.Context, *SockTrace) context.Context #58
 pkg net, func ContextSockTrace(context.Context) *SockTrace #58
 pkg net, type SockTrace struct #58

--- a/src/cmd/dist/build.go
+++ b/src/cmd/dist/build.go
@@ -393,6 +393,12 @@ func findgoversion() string {
 		// its content if available, which is empty at this point.
 		// Only use the VERSION file if it is non-empty.
 		if b != "" {
+			if rev := os.Getenv("TAILSCALE_TOOLCHAIN_REV"); rev != "" {
+				if len(rev) > 10 {
+					rev = rev[:10]
+				}
+				b += "-ts" + chomp(rev)
+			}
 			return b
 		}
 	}

--- a/src/cmd/dist/buildgo.go
+++ b/src/cmd/dist/buildgo.go
@@ -7,7 +7,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -119,7 +118,7 @@ func mkzcgo(dir, file string) {
 	writeHeader(&buf)
 	fmt.Fprintf(&buf, "package build\n")
 	fmt.Fprintln(&buf)
-	fmt.Fprintf(&buf, "const defaultCGO_ENABLED = %s\n", quote(os.Getenv("CGO_ENABLED")))
+	fmt.Fprintf(&buf, "const defaultCGO_ENABLED = %q\n", "")
 
 	writefile(buf.String(), file, writeSkipSame)
 }

--- a/src/cmd/go/internal/cache/default.go
+++ b/src/cmd/go/internal/cache/default.go
@@ -59,7 +59,9 @@ func initDefaultCache() {
 		base.Fatalf("failed to initialize build cache at %s: %s\n", dir, err)
 	}
 
-	if v := cfg.Getenv("GOCACHEPROG"); v != "" && goexperiment.CacheProg {
+	// We don't require the GOEXPERIMENT in Tailscale's Go tree.
+	const isTailscaleGoTree = true
+	if v := cfg.Getenv("GOCACHEPROG"); v != "" && (isTailscaleGoTree || goexperiment.CacheProg) {
 		defaultCache = startCacheProg(v, diskCache)
 	} else {
 		defaultCache = diskCache

--- a/src/net/fd_posix.go
+++ b/src/net/fd_posix.go
@@ -24,6 +24,11 @@ type netFD struct {
 	net         string
 	laddr       Addr
 	raddr       Addr
+
+	// hooks (if provided) are called after successful reads or writes with the
+	// number of bytes transferred.
+	readHook  func(int)
+	writeHook func(int)
 }
 
 func (fd *netFD) setAddr(laddr, raddr Addr) {
@@ -53,83 +58,125 @@ func (fd *netFD) closeWrite() error {
 
 func (fd *netFD) Read(p []byte) (n int, err error) {
 	n, err = fd.pfd.Read(p)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, wrapSyscallError(readSyscallName, err)
 }
 
 func (fd *netFD) readFrom(p []byte) (n int, sa syscall.Sockaddr, err error) {
 	n, sa, err = fd.pfd.ReadFrom(p)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, sa, wrapSyscallError(readFromSyscallName, err)
 }
 func (fd *netFD) readFromInet4(p []byte, from *syscall.SockaddrInet4) (n int, err error) {
 	n, err = fd.pfd.ReadFromInet4(p, from)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, wrapSyscallError(readFromSyscallName, err)
 }
 
 func (fd *netFD) readFromInet6(p []byte, from *syscall.SockaddrInet6) (n int, err error) {
 	n, err = fd.pfd.ReadFromInet6(p, from)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, wrapSyscallError(readFromSyscallName, err)
 }
 
 func (fd *netFD) readMsg(p []byte, oob []byte, flags int) (n, oobn, retflags int, sa syscall.Sockaddr, err error) {
 	n, oobn, retflags, sa, err = fd.pfd.ReadMsg(p, oob, flags)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n + oobn)
+	}
 	runtime.KeepAlive(fd)
 	return n, oobn, retflags, sa, wrapSyscallError(readMsgSyscallName, err)
 }
 
 func (fd *netFD) readMsgInet4(p []byte, oob []byte, flags int, sa *syscall.SockaddrInet4) (n, oobn, retflags int, err error) {
 	n, oobn, retflags, err = fd.pfd.ReadMsgInet4(p, oob, flags, sa)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n + oobn)
+	}
 	runtime.KeepAlive(fd)
 	return n, oobn, retflags, wrapSyscallError(readMsgSyscallName, err)
 }
 
 func (fd *netFD) readMsgInet6(p []byte, oob []byte, flags int, sa *syscall.SockaddrInet6) (n, oobn, retflags int, err error) {
 	n, oobn, retflags, err = fd.pfd.ReadMsgInet6(p, oob, flags, sa)
+	if fd.readHook != nil && err == nil {
+		fd.readHook(n + oobn)
+	}
 	runtime.KeepAlive(fd)
 	return n, oobn, retflags, wrapSyscallError(readMsgSyscallName, err)
 }
 
 func (fd *netFD) Write(p []byte) (nn int, err error) {
 	nn, err = fd.pfd.Write(p)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(nn)
+	}
 	runtime.KeepAlive(fd)
 	return nn, wrapSyscallError(writeSyscallName, err)
 }
 
 func (fd *netFD) writeTo(p []byte, sa syscall.Sockaddr) (n int, err error) {
 	n, err = fd.pfd.WriteTo(p, sa)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, wrapSyscallError(writeToSyscallName, err)
 }
 
 func (fd *netFD) writeToInet4(p []byte, sa *syscall.SockaddrInet4) (n int, err error) {
 	n, err = fd.pfd.WriteToInet4(p, sa)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, wrapSyscallError(writeToSyscallName, err)
 }
 
 func (fd *netFD) writeToInet6(p []byte, sa *syscall.SockaddrInet6) (n int, err error) {
 	n, err = fd.pfd.WriteToInet6(p, sa)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(n)
+	}
 	runtime.KeepAlive(fd)
 	return n, wrapSyscallError(writeToSyscallName, err)
 }
 
 func (fd *netFD) writeMsg(p []byte, oob []byte, sa syscall.Sockaddr) (n int, oobn int, err error) {
 	n, oobn, err = fd.pfd.WriteMsg(p, oob, sa)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(n + oobn)
+	}
 	runtime.KeepAlive(fd)
 	return n, oobn, wrapSyscallError(writeMsgSyscallName, err)
 }
 
 func (fd *netFD) writeMsgInet4(p []byte, oob []byte, sa *syscall.SockaddrInet4) (n int, oobn int, err error) {
 	n, oobn, err = fd.pfd.WriteMsgInet4(p, oob, sa)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(n + oobn)
+	}
 	runtime.KeepAlive(fd)
 	return n, oobn, wrapSyscallError(writeMsgSyscallName, err)
 }
 
 func (fd *netFD) writeMsgInet6(p []byte, oob []byte, sa *syscall.SockaddrInet6) (n int, oobn int, err error) {
 	n, oobn, err = fd.pfd.WriteMsgInet6(p, oob, sa)
+	if fd.writeHook != nil && err == nil {
+		fd.writeHook(n + oobn)
+	}
 	runtime.KeepAlive(fd)
 	return n, oobn, wrapSyscallError(writeMsgSyscallName, err)
 }

--- a/src/net/http/tailscale.go
+++ b/src/net/http/tailscale.go
@@ -1,0 +1,21 @@
+package http
+
+var roundTripEnforcer func(*Request) error
+
+// SetRoundTripEnforcer set a program-global resolver enforcer that can cause
+// RoundTrip calls to fail based on the request and its context.
+//
+// f must be non-nil.
+//
+// SetRoundTripEnforcer can only be called once, and must not be called
+// concurrent with any RoundTrip call; it's expected to be registered during
+// init.
+func SetRoundTripEnforcer(f func(*Request) error) {
+	if f == nil {
+		panic("nil func")
+	}
+	if roundTripEnforcer != nil {
+		panic("already called")
+	}
+	roundTripEnforcer = f
+}

--- a/src/net/http/transport.go
+++ b/src/net/http/transport.go
@@ -515,6 +515,11 @@ func (t *Transport) alternateRoundTripper(req *Request) RoundTripper {
 
 // roundTrip implements a RoundTripper over HTTP.
 func (t *Transport) roundTrip(req *Request) (*Response, error) {
+	if roundTripEnforcer != nil {
+		if err := roundTripEnforcer(req); err != nil {
+			return nil, err
+		}
+	}
 	t.nextProtoOnce.Do(t.onceSetNextProtoDefaults)
 	ctx := req.Context()
 	trace := httptrace.ContextClientTrace(ctx)

--- a/src/net/sock_posix.go
+++ b/src/net/sock_posix.go
@@ -32,17 +32,13 @@ func socket(ctx context.Context, net string, family, sotype, proto int, ipv6only
 		fd.readHook = trace.DidRead
 		fd.writeHook = trace.DidWrite
 		if (trace.DidCreateTCPConn != nil || trace.WillCloseTCPConn != nil) && len(net) >= 3 && net[0:3] == "tcp" {
-			// Ignore newRawConn errors (they're not possible in the current
-			// implementation, but even if they were, we don't want to
-			// affect socket operations for a trace hook invocation).
-			if c, err := newRawConn(fd); err == nil {
-				if trace.DidCreateTCPConn != nil {
-					trace.DidCreateTCPConn(c)
-				}
-				if trace.WillCloseTCPConn != nil {
-					fd.closeHook = func() {
-						trace.WillCloseTCPConn(c)
-					}
+			c := newRawConn(fd)
+			if trace.DidCreateTCPConn != nil {
+				trace.DidCreateTCPConn(c)
+			}
+			if trace.WillCloseTCPConn != nil {
+				fd.closeHook = func() {
+					trace.WillCloseTCPConn(c)
 				}
 			}
 		}

--- a/src/net/sock_posix.go
+++ b/src/net/sock_posix.go
@@ -28,6 +28,10 @@ func socket(ctx context.Context, net string, family, sotype, proto int, ipv6only
 		poll.CloseFunc(s)
 		return nil, err
 	}
+	if trace := ContextSockTrace(ctx); trace != nil {
+		fd.readHook = trace.DidRead
+		fd.writeHook = trace.DidWrite
+	}
 
 	// This function makes a network file descriptor for the
 	// following applications:

--- a/src/net/socktrace.go
+++ b/src/net/socktrace.go
@@ -6,12 +6,16 @@ package net
 
 import (
 	"context"
+	"syscall"
 )
 
 // SockTrace is a set of hooks to run at various operations on a network socket.
 // Any particular hook may be nil. Functions may be called concurrently from
 // different goroutines.
 type SockTrace struct {
+	// DidOpenTCPConn is called when a TCP socket was created. The
+	// underlying raw network connection that was created is provided.
+	DidCreateTCPConn func(c syscall.RawConn)
 	// DidRead is called after a successful read from the socket, where n bytes
 	// were read.
 	DidRead func(n int)
@@ -22,6 +26,9 @@ type SockTrace struct {
 	// subsequent call to WithSockTrace. The provided trace is the new trace
 	// that will be used.
 	WillOverwrite func(trace *SockTrace)
+	// WillCloseTCPConn is called when a TCP socket is about to be closed. The
+	// underlying raw network connection that is being closed is provided.
+	WillCloseTCPConn func(c syscall.RawConn)
 }
 
 // WithSockTrace returns a new context based on the provided parent

--- a/src/net/socktrace.go
+++ b/src/net/socktrace.go
@@ -1,0 +1,46 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"context"
+)
+
+// SockTrace is a set of hooks to run at various operations on a network socket.
+// Any particular hook may be nil. Functions may be called concurrently from
+// different goroutines.
+type SockTrace struct {
+	// DidRead is called after a successful read from the socket, where n bytes
+	// were read.
+	DidRead func(n int)
+	// DidWrite is called after a successful write to the socket, where n bytes
+	// were written.
+	DidWrite func(n int)
+	// WillOverwrite is called when the registered trace is overwritten by a
+	// subsequent call to WithSockTrace. The provided trace is the new trace
+	// that will be used.
+	WillOverwrite func(trace *SockTrace)
+}
+
+// WithSockTrace returns a new context based on the provided parent
+// ctx. Socket reads and writes made with the returned context will use
+// the provided trace hooks. Any previous hooks registered with ctx are
+// ovewritten (their WillOverwrite hook will be called).
+func WithSockTrace(ctx context.Context, trace *SockTrace) context.Context {
+	if previous := ContextSockTrace(ctx); previous != nil && previous.WillOverwrite != nil {
+		previous.WillOverwrite(trace)
+	}
+	return context.WithValue(ctx, sockTraceKey{}, trace)
+}
+
+// ContextSockTrace returns the SockTrace associated with the
+// provided context. If none, it returns nil.
+func ContextSockTrace(ctx context.Context) *SockTrace {
+	trace, _ := ctx.Value(sockTraceKey{}).(*SockTrace)
+	return trace
+}
+
+// unique type to prevent assignment.
+type sockTraceKey struct{}

--- a/src/net/udpsock_posix.go
+++ b/src/net/udpsock_posix.go
@@ -217,6 +217,10 @@ func (sd *sysDialer) dialUDP(ctx context.Context, laddr, raddr *UDPAddr) (*UDPCo
 }
 
 func (sl *sysListener) listenUDP(ctx context.Context, laddr *UDPAddr) (*UDPConn, error) {
+	if panicOnUnspecListen(laddr.IP) {
+		panic("tailscale: can't listen on unspecified address in test")
+	}
+
 	var ctrlCtxFn func(cxt context.Context, network, address string, c syscall.RawConn) error
 	if sl.ListenConfig.Control != nil {
 		ctrlCtxFn = func(cxt context.Context, network, address string, c syscall.RawConn) error {


### PR DESCRIPTION
Doing a rebase got messy because of all the cherry-picks on the 1.21 branch.
Here's what I did:
* create new branch `tailscale.go1.22` from upstream `release-branch.go1.22`
* create new branch `update-go1.22.0` from `tailscale.go1.22` (this PR branch)
* cherry-pick all Tailscale patches from `tailscale.go1.21` into `update-go.1.22.0`
* amend a few commit messages with a `[tailscale]` prefix to make our patches easier to find in the future

To validate, here's the diff from upstream `release-branch.go1.21` to our `tailscale.go1.21`: https://github.com/golang/go/compare/release-branch.go1.21...tailscale:go:tailscale.go1.21 - these are all the patches in our current toolchain.
Here's the diff from upstream `release-branch.go1.22` to this PR branch: https://github.com/golang/go/compare/release-branch.go1.22...tailscale:go:update-go1.22.0

It's identical, except for a change in `src/time/time.go` that has been upstreamed: https://github.com/golang/go/commit/446783960277251fcb837f3672f377469d204918

Fixes https://github.com/tailscale/go/issues/70