### PR TITLE
net: don't wait 5 seconds to re-read /etc/resolv.conf

### DIFF
--- a/src/net/conf_test.go
+++ b/src/net/conf_test.go
@@ -396,7 +396,7 @@ func TestConfHostLookupOrder(t *testing.T) {
 	defer conf.teardown()
 
 	for _, tt := range tests {
-		if !conf.forceUpdateConf(tt.resolv, time.Now().Add(time.Hour)) {
+		if !conf.forceUpdateConf(tt.resolv, distantFuture) {
 			t.Errorf("%s: failed to change resolv config", tt.name)
 		}
 		for _, ht := range tt.hostTests {


### PR DESCRIPTION
If a Go process starts up, finds /etc/resolv.conf empty, then the DHCP
client writes /etc/resolv.conf, the Go program would find itself
broken for up to 5 seconds.

Updates tailscale/corp#22206
