### PR TITLE
github: bump artifact actions version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Documentation for this file can be found at:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ".github:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,11 +59,14 @@ jobs:
         find . -name '*_test.go' -delete
     - name: archive
       run: cd .. && tar --exclude-vcs -zcf ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz go
+    - name: Set artifacts_path in env (workaround for actions/upload-artifact#176)
+      run: |
+        echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV
     - name: save
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0 
       with:
         name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
-        path: ../${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+        path: ${{ env.artifacts_path }}/${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
 
   create_release:
     runs-on: ubuntu-20.04
@@ -94,7 +97,7 @@ jobs:
     needs: [create_release]
     steps:
     - name: download artifact
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
     - name: upload artifact


### PR DESCRIPTION
Update .github/workflows/build.yml to use v4s of the upload-artifact and download-artifact actions. Adds a workaround for actions/upload-artifact#176.

Co-authored-by: Mario Minardi <mminardi@shaw.ca>