### PR TITLE
.github: fix asset_path for upload_release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.url }}
-        asset_path: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}/${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+        asset_path: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
         asset_name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
         asset_content_type: application/gzip
 


### PR DESCRIPTION
Adjust asset_path for upload_release to the bare filename as the download-artifact action now drops the tarballs under the work directory by default.