### PR TITLE
[tailscale] .github: update actions/checkout to 4.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: test
@@ -38,7 +38,7 @@ jobs:
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: build
@@ -118,7 +118,7 @@ jobs:
     needs: [upload_release]
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: Delete older builds


### PR DESCRIPTION
Update actions/checkout to 4.x as the version of node used in 3.x is deprecated for GitHub actions.

Updates #cleanup
