### PR TITLE
[tailscale] .github: stop using upload-release-asset action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,14 +101,10 @@ jobs:
       with:
         name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
     - name: upload artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
       with:
-        upload_url: ${{ needs.create_release.outputs.url }}
-        asset_path: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
-        asset_name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
-        asset_content_type: application/gzip
+        files: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   clean_old:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: test
@@ -38,7 +38,7 @@ jobs:
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: build
@@ -118,7 +118,7 @@ jobs:
     needs: [upload_release]
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: Delete older builds


### PR DESCRIPTION
Change to use `action-gh-release` instead of `upload-release-asset` as the repo for `upload-release-asset` is in public archive and recommends swapping over to `action-gh-release`.

Updates TODO