### PR TITLE
[tailscale] runtime/debug: embed Tailscale toolchain git rev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ inputs.ref || github.ref }}
+    - name: set runtime/debug.tailscaleGitRev
+      run: sed -i "s/TAILSCALE_GIT_REV_TO_BE_REPLACED_AT_BUILD_TIME/${{ github.sha }}/" src/runtime/debug/mod.go
     - name: build
       run: cd src && ./make.bash
       env:

--- a/src/runtime/debug/mod.go
+++ b/src/runtime/debug/mod.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 )
 
+const tailscaleGitRev = `TAILSCALE_GIT_REV_TO_BE_REPLACED_AT_BUILD_TIME`
+
 // exported from runtime.
 func modinfo() string
 
@@ -33,6 +35,13 @@ func ReadBuildInfo() (info *BuildInfo, ok bool) {
 	// ParseBuildInfo does not recognize it. We inject it here to hide this
 	// awkwardness from the user.
 	bi.GoVersion = runtime.Version()
+
+	if len(tailscaleGitRev) > 0 && tailscaleGitRev[0] != 'T' {
+		bi.Settings = append(bi.Settings, BuildSetting{
+			Key:   "tailscale.toolchain.rev",
+			Value: tailscaleGitRev,
+		})
+	}
 
 	return bi, true
 }


### PR DESCRIPTION
This is another take on #49 (which we stopped using?), and less
intrusive, and also always on.

This puts puts the the Tailscale Go toolchain's git rev in
the binary, accessible as runtime/debug.TailscaleGitRev.

Caller code will have to access it guarded by the "tailscale_go" build
tag.

Updates #49
