### PR TITLE
.github: include windows output in release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,11 @@ jobs:
   upload_release:
     strategy:
       matrix:
-        GOOS: ["linux", "darwin"]
+        GOOS: ["linux", "darwin", "windows"]
         GOARCH: ["amd64", "arm64"]
+        exclude:
+          - GOOS: windows
+            GOARCH: arm64
     runs-on: ubuntu-20.04
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [create_release]


### PR DESCRIPTION
I missed this in #106

Updates tailscale/corp#24680

Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
