### PR TITLE
[tailscale] .github: bump to latest ubuntu LTS in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -37,7 +37,7 @@ jobs:
         exclude:
           - GOOS: windows
             GOARCH: arm64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:
     - name: checkout
@@ -74,7 +74,7 @@ jobs:
         path: ${{ env.artifacts_path }}/${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
 
   create_release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [test, build_release]
     outputs:
@@ -100,7 +100,7 @@ jobs:
         exclude:
           - GOOS: windows
             GOARCH: arm64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [create_release]
     steps:
@@ -119,7 +119,7 @@ jobs:
         asset_content_type: application/gzip
 
   clean_old:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # Do not clean up old builds on workflow_dispatch to allow temporarily
     # re-creating old releases for backports.
     if: github.event_name == 'push'


### PR DESCRIPTION
Use `ubuntu-24.04` instead of `20.04` as the latter is EOL in May 2025.

Updates https://github.com/tailscale/go/issues/47