### PR TITLE
.github/workflows: add `skipTests` option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,16 @@ on:
         description: Branch, commit or tag to build from
         required: true
         default: 'tailscale.go1.24'
+      skipTests:
+        description: Whether to skip tests. This should only be used in break-glass / extraordinary scenarios.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test:
     runs-on: ubuntu-24.04
+    if: ${{ !inputs.skipTests }}
     steps:
     - name: checkout
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
Add `skipTests` option to build.yml to allow for skipping tests in extraordinary circumstances.

Updates https://github.com/tailscale/go/issues/47