### PR TITLE
.github/workflows: add `always()` logic to `upload_release` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
         # Release name can't be the same as tag name, sigh
         tag_name: build-${{ inputs.ref || github.sha }}
         release_name: ${{ inputs.ref || github.sha }}
+        commitish: ${{ inputs.ref || github.sha }}
         draft: false
         prerelease: true
 
@@ -112,7 +113,10 @@ jobs:
           - GOOS: windows
             GOARCH: arm64
     runs-on: ubuntu-24.04
-    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+    # We need to do the `always()` hack here as well since the upstream `create_release` job
+    # needs it and this seems to transitively require that downstream jobs also have a similar
+    # check.
+    if: always() && contains(needs.create_release.result, 'success') && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [create_release]
     steps:
     - name: download artifact


### PR DESCRIPTION
Add `always()` logic to `upload_release` job as it seems like using the
`always()` hack in an upstream `needs` dependency may force downstream
jobs to also use `always()`, presumably because GitHub is doing
transitive dependency checking upstream and sees that the original
`test` job was skipped.

Pass explicit `commitsh` argument to the `create-release` action to
ensure the resulting tag / release is tied to the intended SHA and not
the branch the job was triggered from. As an example, before this change
triggering the workflow from the `tailscale.go1.24` branch would always
result in the tag being added to the head of `tailscale.go1.24` instead
of at the `ref` that the release was actually built from.

Updates https://github.com/tailscale/go/issues/47
