### PR TITLE
.github/workflows: embed SHA from checkout instead of github.sha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,12 @@ jobs:
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:
     - name: checkout
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      id: checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ inputs.ref || github.ref }}
     - name: set runtime/debug.tailscaleGitRev
-      run: sed -i "s/TAILSCALE_GIT_REV_TO_BE_REPLACED_AT_BUILD_TIME/${{ github.sha }}/" src/runtime/debug/mod.go
+      run: sed -i "s/TAILSCALE_GIT_REV_TO_BE_REPLACED_AT_BUILD_TIME/${{ steps.checkout.outputs.commit }}/" src/runtime/debug/mod.go
     - name: build
       run: cd src && ./make.bash
       env:


### PR DESCRIPTION
Embed the commit SHA that we have checked out instead of `github.sha` into `mod.go` at build time as `github.sha` will point to the incorrect commit when running as a workflow_dispatch with `ref` specified.

Updates https://github.com/tailscale/go/issues/47
Updates https://github.com/tailscale/corp/issues/26875
