### PR TITLE
.github/workflows: remove usage of GitHub application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,25 +92,18 @@ jobs:
     outputs:
       url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-    - name: create app token
-      uses: actions/create-github-app-token@v1
-      id: app-token
-      with:
-        # required
-        app-id: ${{ vars.TS_LEGACY_BUILDER_APP_ID }}
-        private-key: ${{ secrets.TS_LEGACY_BUILDER_PRIVKEY }}
-    - name: create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      with:
-        # Release name can't be the same as tag name, sigh
-        tag_name: build-${{ inputs.ref || github.sha }}
-        release_name: ${{ inputs.ref || github.sha }}
-        commitish: ${{ inputs.ref || github.sha }}
-        draft: false
-        prerelease: true
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Release name can't be the same as tag name, sigh
+          tag_name: build-${{ inputs.ref || github.sha }}
+          release_name: ${{ inputs.ref || github.sha }}
+          commitish: ${{ inputs.ref || github.sha }}
+          draft: false
+          prerelease: true
 
   upload_release:
     strategy:


### PR DESCRIPTION
Remove usage of GitHub application from the workflow now that historical releases have been regenerated.

Updates https://github.com/tailscale/go/issues/47
Updates https://github.com/tailscale/corp/issues/26875