### PR TITLE
.github/workflows: enable building of arm64 windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,6 @@ jobs:
       matrix:
         GOOS: ["linux", "darwin", "windows"]
         GOARCH: ["amd64", "arm64"]
-        exclude:
-          - GOOS: windows
-            GOARCH: arm64
     runs-on: ubuntu-24.04
     if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     steps:


### PR DESCRIPTION
We now have some engineers using a VM running ARM64 Windows on their MacBooks. We should build a native toolchain for that use case.