### PR TITLE
[tailscale] src/crypto/tls: add tls.Config.IgnoreClientKeyExtUsageClientAuth

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -883,6 +883,10 @@ type Config struct {
 	// autoSessionTicketKeys is like sessionTicketKeys but is owned by the
 	// auto-rotation logic. See Config.ticketKeys.
 	autoSessionTicketKeys []ticketKey
+	// IgnoreClientKeyExtUsageClientAuth disables the requirement for client TLS
+	// certificates presented to the server to include the
+	// `x509.ExtKeyUsageClientAuth` key usage attribute.
+	IgnoreClientKeyExtUsageClientAuth bool
 }
 
 // EncryptedClientHelloKey holds a private key that is associated

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -963,6 +963,13 @@ func (c *Conn) processCertsFromClient(certificate Certificate) error {
 			opts.Intermediates.AddCert(cert)
 		}
 
+		// optionally allow client certs with ExtKeyUsageServerAuth to permit LE
+		// certs to work past October 1, 2025 ExtKeyUsageClientAuth deprecation
+		// ref: http://go/corp/28569
+		if c.config.IgnoreClientKeyExtUsageClientAuth {
+			opts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		}
+
 		chains, err := certs[0].Verify(opts)
 		if err != nil {
 			var errCertificateInvalid x509.CertificateInvalidError


### PR DESCRIPTION
Optionally allow the use of TLS certificates with `ExtKeyUsageServerAuth` and not `ExtKeyUsageClientAuth` for peer TLS connections to permit Let's Encrypt issued certificates to function for mTLS past their October 1, 2025 deprecation of the `ExtKeyUsageClientAuth` attribute.

Updates tailscale/corp#28569
