### PR TITLE
[tailscale] net/http: add SetResponseWriteEnforcer

### DIFF
--- a/api/go1.5255.txt
+++ b/api/go1.5255.txt
@@ -1,3 +1,4 @@
 pkg net, func SetDialEnforcer(func(context.Context, []Addr) error) #55
 pkg net, func SetResolveEnforcer(func(context.Context, string, string, string, Addr) error) #55
 pkg net/http, func SetRoundTripEnforcer(func(*Request) error) #55
+pkg net/http, func SetResponseWriteEnforcer(func(*Request)) #55

--- a/src/net/http/h2_bundle.go
+++ b/src/net/http/h2_bundle.go
@@ -6921,6 +6921,9 @@ func (rws *http2responseWriterState) writeHeader(code int) {
 	if rws.wroteHeader {
 		return
 	}
+	if responseWriteEnforcer != nil {
+		responseWriteEnforcer(rws.req)
+	}
 
 	http2checkWriteHeaderCode(code)
 

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -1193,6 +1193,9 @@ func (w *response) WriteHeader(code int) {
 		w.conn.server.logf("http: superfluous response.WriteHeader call from %s (%s:%d)", caller.Function, path.Base(caller.File), caller.Line)
 		return
 	}
+	if responseWriteEnforcer != nil {
+		responseWriteEnforcer(w.req)
+	}
 	checkWriteHeaderCode(code)
 
 	if code < 101 || code > 199 {

--- a/src/net/http/tailscale.go
+++ b/src/net/http/tailscale.go
@@ -6,7 +6,9 @@ package http
 
 var roundTripEnforcer func(*Request) error
 
-// SetRoundTripEnforcer set a program-global resolver enforcer that can cause
+var responseWriteEnforcer func(*Request)
+
+// SetRoundTripEnforcer sets a program-global resolver enforcer that can cause
 // RoundTrip calls to fail based on the request and its context.
 //
 // f must be non-nil.
@@ -22,4 +24,26 @@ func SetRoundTripEnforcer(f func(*Request) error) {
 		panic("already called")
 	}
 	roundTripEnforcer = f
+}
+
+// SetResponseWriteEnforcer sets a program-global response writing enforcer
+// which can panic to interrupt the sending of a response.
+//
+// f must be non-nil.
+//
+// SetResponseWriteEnforcer can only be called once, and must not be called
+// concurrent with any ResponseWriter.WriteHeader call; it's expected to be
+// registered during init.
+//
+// f only accepts a *Request - and not the ResponseWriter - because the
+// http2responseWriterState is free to write its own status line and has no
+// reference to the http2responseWriter.
+func SetResponseWriteEnforcer(f func(*Request)) {
+	if f == nil {
+		panic("nil func")
+	}
+	if responseWriteEnforcer != nil {
+		panic("already called")
+	}
+	responseWriteEnforcer = f
 }

--- a/src/net/http/tailscale_test.go
+++ b/src/net/http/tailscale_test.go
@@ -1,0 +1,104 @@
+// Copyright 2023 Tailscale. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http_test
+
+import (
+	"io"
+	"log"
+	"net/http"
+	. "net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func init() {
+	SetResponseWriteEnforcer(func(r *http.Request) {
+		respEnf.mu.Lock()
+		fs := slices.Clone(respEnf.fs)
+		respEnf.mu.Unlock()
+
+		for _, f := range fs {
+			if f != nil {
+				f(r)
+			}
+		}
+	})
+}
+
+var respEnf = struct {
+	mu sync.Mutex
+	fs []func(*Request)
+}{}
+
+func addResponseWriteEnforcer(f func(*Request)) (cleanup func()) {
+	respEnf.mu.Lock()
+	defer respEnf.mu.Unlock()
+	n := len(respEnf.fs)
+	respEnf.fs = append(respEnf.fs, f)
+
+	return func() {
+		respEnf.mu.Lock()
+		defer respEnf.mu.Unlock()
+		respEnf.fs[n] = nil
+	}
+}
+
+func TestSetResponseWriteEnforcer(t *testing.T) {
+	run(t, testSetResponseWriteEnforcer, testNotParallel)
+}
+func testSetResponseWriteEnforcer(t *testing.T, mode testMode) {
+	var found atomic.Bool
+	remove := addResponseWriteEnforcer(func(r *Request) {
+		t.Logf("addResponseWriteEnforcer: %s %s", r.Method, r.URL)
+		if r.URL.Query().Get("t") == t.Name() {
+			found.Store(true)
+		}
+	})
+	defer remove()
+
+	errLog := new(strings.Builder)
+	defer func() {
+		if t.Failed() && errLog.Len() > 0 {
+			t.Logf("error logs:\n%s", errLog)
+		}
+	}()
+
+	cst := newClientServerTest(t, mode, HandlerFunc(func(w ResponseWriter, r *Request) {
+		if !r.URL.Query().Has("noop") {
+			io.WriteString(w, t.Name())
+		}
+	}),
+		func(ts *httptest.Server) {
+			ts.Config.ReadTimeout = 250 * time.Millisecond
+			ts.Config.ErrorLog = log.New(errLog, "", 0)
+		},
+	)
+	ts := cst.ts
+	client := ts.Client()
+
+	for _, q := range []string{"", "&noop=1"} {
+		found.Store(false)
+
+		u := ts.URL + "?t=" + url.QueryEscape(t.Name()) + q
+		t.Log("GET", u)
+		res, err := client.Get(u)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %s", err)
+		}
+		b, err := httputil.DumpResponse(res, true)
+		t.Logf("Response: error(%v)%s", err, b)
+
+		if !found.Load() {
+			t.Errorf("request %s did not reach SetResponseWriteEnforcer callback", q)
+		}
+	}
+}


### PR DESCRIPTION
The idea with this change is to inject the Tracker into the Request context with http.Server.BaseContext so that it is accessible in the SetResponseWriteEnforcer callback. Close the injected Tracker in a defer at the first layer of handle.

This is only adding enforcement at the time of WriteHeader, which is often implicitly called during the first Write. But this enforcement wouldn't catch the following pattern:

```go
w.WriteHeader(200)
tx := db.Tx(ctx)
defer tx.Rollback()
w.Write(blob)
```

Updates tailscale/corp#7821
Updates #55