### PR TITLE
[tailscale] runtime: add TailscaleNumTimers for metrics

### DIFF
--- a/api/go1.52141.txt
+++ b/api/go1.52141.txt
@@ -1,0 +1,1 @@
+pkg runtime, func TailscaleNumTimers() (int, int)  #141

--- a/src/runtime/tailscale_runtime.go
+++ b/src/runtime/tailscale_runtime.go
@@ -10,3 +10,24 @@ package runtime
 func TailscaleCurrentP() int {
 	return int(getg().m.p.ptr().id)
 }
+
+// TailscaleNumTimers returns the number of timers that are currently
+// pending in the runtime across all Ps, as well as the number of "zombie"
+// timers.
+func TailscaleNumTimers() (total, zombies int) {
+	var sum uint32
+	var nzombies int32
+
+	// Prevent allp slice changes. This is like retake.
+	lock(&allpLock)
+	for _, pp := range allp {
+		if pp == nil {
+			continue
+		}
+		sum += pp.timers.len.Load()
+		nzombies += pp.timers.zombies.Load()
+	}
+	unlock(&allpLock)
+
+	return int(sum), int(nzombies)
+}


### PR DESCRIPTION
Updates tailscale/go#141
