### PR TITLE
[tailscale] runtime: respect GOTRACEBACK for user-triggered runtime panics

### DIFF
--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -39,7 +39,7 @@ func gotraceback() (level int32, all, crash bool) {
 	gp := getg()
 	t := atomic.Load(&traceback_cache)
 	crash = t&tracebackCrash != 0
-	all = gp.m.throwing >= throwTypeUser || t&tracebackAll != 0
+	all = gp.m.throwing > throwTypeUser || t&tracebackAll != 0
 	if gp.m.traceback != 0 {
 		level = int32(gp.m.traceback)
 	} else if gp.m.throwing >= throwTypeRuntime {


### PR DESCRIPTION
This cherry-picks https://go.dev/cl/649535.

Updates tailscale/corp#26605