### PR TITLE
net/http: add ResponseController.SetWriteContextTailscale

### DIFF
--- a/api/go1.5255.txt
+++ b/api/go1.5255.txt
@@ -2,3 +2,4 @@ pkg net, func SetDialEnforcer(func(context.Context, []Addr) error) #55
 pkg net, func SetResolveEnforcer(func(context.Context, string, string, string, Addr) error) #55
 pkg net/http, func SetRoundTripEnforcer(func(*Request) error) #55
 pkg net/http, func SetResponseWriteEnforcer(func(*Request)) #55
+pkg net/http, method (*ResponseController) SetWriteContextTailscale(context.Context) (*Request, error) #55

--- a/src/net/http/h2_bundle.go
+++ b/src/net/http/h2_bundle.go
@@ -6858,6 +6858,15 @@ func (w *http2responseWriter) EnableFullDuplex() error {
 	return nil
 }
 
+func (w *http2responseWriter) SetWriteContextTailscale(ctx context.Context) (*Request, error) {
+	rws := w.rws
+	if rws == nil {
+		panic("SetWriteContextTailscale called after Handler finished")
+	}
+	rws.req = rws.req.WithContext(ctx)
+	return rws.req, nil
+}
+
 func (w *http2responseWriter) Flush() {
 	w.FlushError()
 }

--- a/src/net/http/responsecontroller.go
+++ b/src/net/http/responsecontroller.go
@@ -6,6 +6,7 @@ package http
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -136,6 +137,35 @@ func (c *ResponseController) EnableFullDuplex() error {
 			rw = t.Unwrap()
 		default:
 			return errNotSupported()
+		}
+	}
+}
+
+// SetWriteContextTailscale sets the context on the response's internal request
+// so that the responseWriteEnforcer (registered via SetResponseWriteEnforcer)
+// can see context values set by handler middleware.
+//
+// It returns the new *Request with the updated context, which callers can use
+// directly instead of separately calling r.WithContext(ctx):
+//
+//	r, _ = http.NewResponseController(w).SetWriteContextTailscale(ctx)
+//
+// Without this, handler middleware that calls r.WithContext(ctx) creates a new
+// *Request, but the response's internal w.req still points to the original
+// request with the old context. The enforcer receives w.req, so it cannot see
+// values like the cfgdb txTracker that middleware adds to the context.
+func (c *ResponseController) SetWriteContextTailscale(ctx context.Context) (*Request, error) {
+	rw := c.rw
+	for {
+		switch t := rw.(type) {
+		case interface {
+			SetWriteContextTailscale(context.Context) (*Request, error)
+		}:
+			return t.SetWriteContextTailscale(ctx)
+		case rwUnwrapper:
+			rw = t.Unwrap()
+		default:
+			return nil, errNotSupported()
 		}
 	}
 }

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -509,6 +509,22 @@ func (c *response) EnableFullDuplex() error {
 	return nil
 }
 
+// SetWriteContextTailscale sets the context on the response's internal request
+// so that the responseWriteEnforcer (registered via SetResponseWriteEnforcer)
+// can see context values set by handler middleware.
+//
+// It returns the new *Request with the updated context, which callers can use
+// directly instead of separately calling r.WithContext(ctx).
+//
+// Without this, handler middleware that calls r.WithContext(ctx) creates a new
+// *Request, but the response's internal w.req still points to the original
+// request with the old context. The enforcer receives w.req, so it cannot see
+// values like the cfgdb txTracker that middleware adds to the context.
+func (w *response) SetWriteContextTailscale(ctx context.Context) (*Request, error) {
+	w.req = w.req.WithContext(ctx)
+	return w.req, nil
+}
+
 // TrailerPrefix is a magic prefix for [ResponseWriter.Header] map keys
 // that, if present, signals that the map entry is actually for
 // the response trailers, and not the response headers. The prefix


### PR DESCRIPTION
SetWriteContextTailscale sets the context on the response's internal
request so that the responseWriteEnforcer (registered via
SetResponseWriteEnforcer) can see context values set by handler
middleware.

Without this, handler middleware that calls r.WithContext(ctx) creates
a new *Request, but the response's internal w.req still points to the
original request with the old context. The enforcer receives w.req, so
it cannot see values like the cfgdb txTracker that middleware adds to
the context.

The method returns the new *Request so callers can use it directly
instead of separately calling r.WithContext:

    r, _ = http.NewResponseController(w).SetWriteContextTailscale(ctx)

Updates tailscale/go#55
Updates tailscale/corp#8944
