### PR TITLE
runtime: fix value of ENOSYS on mips from 38 to 89

### DIFF
--- a/src/runtime/defs_linux_mips64x.go
+++ b/src/runtime/defs_linux_mips64x.go
@@ -12,7 +12,7 @@ const (
 	_EINTR  = 0x4
 	_EAGAIN = 0xb
 	_ENOMEM = 0xc
-	_ENOSYS = 0x26
+	_ENOSYS = 0x59
 
 	_PROT_NONE  = 0x0
 	_PROT_READ  = 0x1

--- a/src/runtime/defs_linux_mipsx.go
+++ b/src/runtime/defs_linux_mipsx.go
@@ -12,7 +12,7 @@ const (
 	_EINTR  = 0x4
 	_EAGAIN = 0xb
 	_ENOMEM = 0xc
-	_ENOSYS = 0x26
+	_ENOSYS = 0x59
 
 	_PROT_NONE  = 0x0
 	_PROT_READ  = 0x1


### PR DESCRIPTION
Updates tailscale/go#160
Updates tailscale/tailscale#19039
Updates golang/go#77730
Updates golang/go#77731 (Go 1.26 backport)

Cherry-picked from https://go-review.googlesource.com/c/go/+/747664 v7

Change-Id: I8b68b2d4353344e70f970d48a2d50c1a3bd7f273
Reviewed-on: https://go-review.googlesource.com/c/go/+/747664
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Cherry Mui <cherryyz@google.com>
Reviewed-by: Rongrong <rongrong-for-oss@oss.cipunited.com>
Reviewed-by: Michael Pratt <mpratt@google.com>