### PR TITLE
runtime: use uname version check for 64-bit time on 32-bit arch codepaths

### DIFF
--- a/src/internal/runtime/syscall/linux/defs_linux_386.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_386.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 295
 	SYS_PREAD64       = 180
 	SYS_READ          = 3
+	SYS_UNAME         = 122
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_amd64.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_amd64.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 257
 	SYS_PREAD64       = 17
 	SYS_READ          = 0
+	SYS_UNAME         = 63
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_arm.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_arm.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 322
 	SYS_PREAD64       = 180
 	SYS_READ          = 3
+	SYS_UNAME         = 122
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_arm64.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_arm64.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 56
 	SYS_PREAD64       = 67
 	SYS_READ          = 63
+	SYS_UNAME         = 160
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_loong64.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_loong64.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 56
 	SYS_PREAD64       = 67
 	SYS_READ          = 63
+	SYS_UNAME         = 160
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_mips64x.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_mips64x.go
@@ -19,6 +19,7 @@ const (
 	SYS_OPENAT        = 5247
 	SYS_PREAD64       = 5016
 	SYS_READ          = 5000
+	SYS_UNAME         = 5061
 
 	EFD_NONBLOCK = 0x80
 

--- a/src/internal/runtime/syscall/linux/defs_linux_mipsx.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_mipsx.go
@@ -19,6 +19,7 @@ const (
 	SYS_OPENAT        = 4288
 	SYS_PREAD64       = 4200
 	SYS_READ          = 4003
+	SYS_UNAME         = 4122
 
 	EFD_NONBLOCK = 0x80
 

--- a/src/internal/runtime/syscall/linux/defs_linux_ppc64x.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_ppc64x.go
@@ -19,6 +19,7 @@ const (
 	SYS_OPENAT        = 286
 	SYS_PREAD64       = 179
 	SYS_READ          = 3
+	SYS_UNAME         = 122
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_riscv64.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_riscv64.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 56
 	SYS_PREAD64       = 67
 	SYS_READ          = 63
+	SYS_UNAME         = 160
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/defs_linux_s390x.go
+++ b/src/internal/runtime/syscall/linux/defs_linux_s390x.go
@@ -17,6 +17,7 @@ const (
 	SYS_OPENAT        = 288
 	SYS_PREAD64       = 180
 	SYS_READ          = 3
+	SYS_UNAME         = 122
 
 	EFD_NONBLOCK = 0x800
 

--- a/src/internal/runtime/syscall/linux/syscall_linux.go
+++ b/src/internal/runtime/syscall/linux/syscall_linux.go
@@ -86,3 +86,17 @@ func Pread(fd int, p []byte, offset int64) (n int, errno uintptr) {
 	}
 	return int(r1), e
 }
+
+type Utsname struct {
+	Sysname    [65]byte
+	Nodename   [65]byte
+	Release    [65]byte
+	Version    [65]byte
+	Machine    [65]byte
+	Domainname [65]byte
+}
+
+func Uname(buf *Utsname) (errno uintptr) {
+	_, _, e := Syscall6(SYS_UNAME, uintptr(unsafe.Pointer(buf)), 0, 0, 0, 0, 0)
+	return e
+}

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -354,6 +354,7 @@ func osinit() {
 	numCPUStartup = getCPUCount()
 	physHugePageSize = getHugePageSize()
 	vgetrandomInit()
+	configure64bitsTimeOn32BitsArchitectures()
 }
 
 var urandom_dev = []byte("/dev/urandom\x00")
@@ -934,4 +935,65 @@ func (c *sigctxt) sigFromSeccomp() bool {
 func mprotect(addr unsafe.Pointer, n uintptr, prot int32) (ret int32, errno int32) {
 	r, _, err := linux.Syscall6(linux.SYS_MPROTECT, uintptr(addr), n, uintptr(prot), 0, 0, 0)
 	return int32(r), int32(err)
+}
+
+type kernelVersion struct {
+	major int
+	minor int
+}
+
+// getKernelVersion returns major and minor kernel version numbers
+// parsed from the uname release field.
+func getKernelVersion() kernelVersion {
+	var buf linux.Utsname
+	if e := linux.Uname(&buf); e != 0 {
+		throw("uname failed")
+	}
+
+	rel := gostringnocopy(&buf.Release[0])
+	major, minor, _, ok := parseRelease(rel)
+	if !ok {
+		throw("failed to parse kernel version from uname")
+	}
+	return kernelVersion{major: major, minor: minor}
+}
+
+// parseRelease parses a dot-separated version number. It follows the
+// semver syntax, but allows the minor and patch versions to be
+// elided.
+func parseRelease(rel string) (major, minor, patch int, ok bool) {
+	// Strip anything after a dash or plus.
+	for i := 0; i < len(rel); i++ {
+		if rel[i] == '-' || rel[i] == '+' {
+			rel = rel[:i]
+			break
+		}
+	}
+
+	next := func() (int, bool) {
+		for i := 0; i < len(rel); i++ {
+			if rel[i] == '.' {
+				ver, err := strconv.Atoi(rel[:i])
+				rel = rel[i+1:]
+				return ver, err == nil
+			}
+		}
+		ver, err := strconv.Atoi(rel)
+		rel = ""
+		return ver, err == nil
+	}
+	if major, ok = next(); !ok || rel == "" {
+		return
+	}
+	if minor, ok = next(); !ok || rel == "" {
+		return
+	}
+	patch, ok = next()
+	return
+}
+
+// GE checks if the running kernel version
+// is greater than or equal to the provided version.
+func (kv kernelVersion) GE(x, y int) bool {
+	return kv.major > x || (kv.major == x && kv.minor >= y)
 }

--- a/src/runtime/os_linux32.go
+++ b/src/runtime/os_linux32.go
@@ -7,9 +7,12 @@
 package runtime
 
 import (
-	"internal/runtime/atomic"
 	"unsafe"
 )
+
+func configure64bitsTimeOn32BitsArchitectures() {
+	use64bitsTimeOn32bits = getKernelVersion().GE(5, 1)
+}
 
 //go:noescape
 func futex_time32(addr unsafe.Pointer, op int32, val uint32, ts *timespec32, addr2 unsafe.Pointer, val3 uint32) int32
@@ -17,17 +20,12 @@ func futex_time32(addr unsafe.Pointer, op int32, val uint32, ts *timespec32, add
 //go:noescape
 func futex_time64(addr unsafe.Pointer, op int32, val uint32, ts *timespec, addr2 unsafe.Pointer, val3 uint32) int32
 
-var isFutexTime32bitOnly atomic.Bool
+var use64bitsTimeOn32bits bool
 
 //go:nosplit
 func futex(addr unsafe.Pointer, op int32, val uint32, ts *timespec, addr2 unsafe.Pointer, val3 uint32) int32 {
-	if !isFutexTime32bitOnly.Load() {
-		ret := futex_time64(addr, op, val, ts, addr2, val3)
-		// futex_time64 is only supported on Linux 5.0+
-		if ret != -_ENOSYS {
-			return ret
-		}
-		isFutexTime32bitOnly.Store(true)
+	if use64bitsTimeOn32bits {
+		return futex_time64(addr, op, val, ts, addr2, val3)
 	}
 	// Downgrade ts.
 	var ts32 timespec32
@@ -45,17 +43,10 @@ func timer_settime32(timerid int32, flags int32, new, old *itimerspec32) int32
 //go:noescape
 func timer_settime64(timerid int32, flags int32, new, old *itimerspec) int32
 
-var isSetTime32bitOnly atomic.Bool
-
 //go:nosplit
 func timer_settime(timerid int32, flags int32, new, old *itimerspec) int32 {
-	if !isSetTime32bitOnly.Load() {
-		ret := timer_settime64(timerid, flags, new, old)
-		// timer_settime64 is only supported on Linux 5.0+
-		if ret != -_ENOSYS {
-			return ret
-		}
-		isSetTime32bitOnly.Store(true)
+	if use64bitsTimeOn32bits {
+		return timer_settime64(timerid, flags, new, old)
 	}
 
 	var newts, oldts itimerspec32
@@ -73,6 +64,5 @@ func timer_settime(timerid int32, flags int32, new, old *itimerspec) int32 {
 		old32 = &oldts
 	}
 
-	// Fall back to 32-bit timer
 	return timer_settime32(timerid, flags, new32, old32)
 }

--- a/src/runtime/os_linux64.go
+++ b/src/runtime/os_linux64.go
@@ -10,6 +10,8 @@ import (
 	"unsafe"
 )
 
+func configure64bitsTimeOn32BitsArchitectures() {}
+
 //go:noescape
 func futex(addr unsafe.Pointer, op int32, val uint32, ts *timespec, addr2 unsafe.Pointer, val3 uint32) int32
 


### PR DESCRIPTION
The previous fallback-on-ENOSYS logic causes issues on forks of Linux.

Android: #77621 (CL 750040 added a workaround with a TODO,
this fixes that TODO)
Causes the OS to terminate the program when running on Android
versions <=10 since the seccomp jail does not know about the 64-bit
time syscall and is configured to terminate the program on any
unknown syscall.

Synology's Linux: #77930
On old versions of Synology's Linux they added custom vendor syscalls
without adding a gap in the syscall numbers, that means when we call
the newer Linux syscall which was added later, Synology's Linux
interprets it as a completely different vendor syscall.

Originally by Jorropo in CL 751340.

Fixes golang/go#77930
Updates tailscale/go#162
Originally https://go-review.googlesource.com/c/go/+/758902/2

Co-authored-by: Jorropo <jorropo.pgm@gmail.com>
Change-Id: I90e15495d9249fd7f6e112f9e3ae8ad1322f56e0
