### PR TITLE
[tailscale] cmd/go: include tailscale.toolchain.rev in build cache salt

### DIFF
--- a/src/cmd/go/internal/cache/tailscale.go
+++ b/src/cmd/go/internal/cache/tailscale.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Tailscale Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cache
+
+import "runtime/debug"
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "tailscale.toolchain.rev" && s.Value != "" {
+			hashSalt = append(hashSalt, ' ')
+			hashSalt = append(hashSalt, s.Value...)
+			return
+		}
+	}
+}


### PR DESCRIPTION
The Tailscale Go fork's VERSION file matches upstream (e.g. "go1.26.1"),
so Go's build cache, keyed by runtime.Version(), doesn't invalidate when
the fork is patched without a version bump. This can cause stale
binaries to be served from cache even after a toolchain fix.

Read the tailscale.toolchain.rev build setting (already populated by CI
and Nix via sed replacement of the placeholder in runtime/debug/mod.go)
and append it to the cache hash salt. When the placeholder hasn't been
replaced (local dev builds, upstream Go), the salt is unchanged.

Updates tailscale/go#166
Updates tailscale/corp#36589
Updates tailscale/tailscale#19263
