### PR TITLE
[tailscale] .github/workflows: fix release creation for immutable releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,10 @@ jobs:
         name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
         path: ${{ env.artifacts_path }}/${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
 
+  # GitHub releases are now immutable: once published, assets can no
+  # longer be added or changed. So we create the release as a draft,
+  # upload all assets to the draft, and only then publish it (in the
+  # publish_release job below).
   create_release:
     runs-on: ubuntu-24.04
     # By default, the "if" check here is skipped if one of the jobs in the "needs" block
@@ -86,21 +90,19 @@ jobs:
     # we are only creating a release when the `test` job has suceeded or been skipped.
     if: always() && contains(needs.build_release.result, 'success') && (contains(needs.test.result, 'success') || contains(needs.test.result, 'skipped')) && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [test, build_release]
-    outputs:
-      url: ${{ steps.create_release.outputs.upload_url }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      REF: ${{ inputs.ref || github.sha }}
     steps:
-      - name: create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Release name can't be the same as tag name, sigh
-          tag_name: build-${{ inputs.ref || github.sha }}
-          release_name: ${{ inputs.ref || github.sha }}
-          commitish: ${{ inputs.ref || github.sha }}
-          draft: false
-          prerelease: true
+      - name: create draft release
+        # Release name can't be the same as tag name, sigh
+        run: |
+          gh release create "build-$REF" \
+            --title "$REF" \
+            --target "$REF" \
+            --draft \
+            --prerelease
 
   upload_release:
     strategy:
@@ -113,17 +115,29 @@ jobs:
     # check.
     if: always() && contains(needs.create_release.result, 'success') && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs: [create_release]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      REF: ${{ inputs.ref || github.sha }}
     steps:
     - name: download artifact
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
-    - name: upload artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.url }}
-        asset_path: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
-        asset_name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
-        asset_content_type: application/gzip
+    - name: upload artifact to draft release
+      run: |
+        gh release upload "build-$REF" \
+          "${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz"
+
+  publish_release:
+    runs-on: ubuntu-24.04
+    if: always() && contains(needs.upload_release.result, 'success') && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+    needs: [upload_release]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      REF: ${{ inputs.ref || github.sha }}
+    steps:
+    - name: publish release
+      run: |
+        gh release edit "build-$REF" --draft=false


### PR DESCRIPTION
GitHub releases are now immutable: once a release is published, assets can no longer be added, so the old create-then-upload flow fails with "Cannot upload assets to an immutable release". Create the release as a draft instead, upload the per-platform tarballs to the draft, and publish it in a new final publish_release job once all uploads succeed.

This also replaces the long-archived actions/create-release and actions/upload-release-asset actions with the gh CLI preinstalled on the runners.

Updates tailscale/go#47

Change-Id: Ib2c50f81d9e4a7302cf9e60dd41908ae7c73f9c4
